### PR TITLE
Updated to verify! connection before using

### DIFF
--- a/lib/dossier/adapter/active_record.rb
+++ b/lib/dossier/adapter/active_record.rb
@@ -16,6 +16,7 @@ module Dossier
       def execute(query, report_name = nil)
         retries ||= 0
 
+        connection.verify!
         Result.new(connection.exec_query(*["\n#{query}", report_name].compact))
       rescue PG::ConnectionBad => e
         if retries < 3
@@ -43,7 +44,7 @@ module Dossier
       def active_record_connection
         @abstract_class = Class.new(::ActiveRecord::Base) do
           self.abstract_class = true
-          
+
           # Needs a unique name for ActiveRecord's connection pool
           def self.name
             "Dossier::Adapter::ActiveRecord::Connection_#{object_id}"


### PR DESCRIPTION
We are getting a lot of PQsocket() can't get socket descriptor errors.

From my understanding this means that we are out of connections BUT this is not true. 
Connections: 59/400

Based on a small amount of samples this is always happening here:
/lib/dossier/adapter/active_record.rb:34

It seems to me that we are getting a connection but we are then loosing the connection before it is being used. We already have code to try to reconnect but that doesn't seem to be working perfectly.

I am hoping that by using connection.verify! we get better results.

This was a solution I found from people who use the octopus gem. They seem to have this issue and someone mentioned using connection.verify! That this solved his problem.


How to test:
- clone repo locally and make sure you are pulling all branches.
- open octopi Gemfile and edit the dossier entry with 
```
gem 'dossier', git: '/full/path/to/dossier', :branch => 'attempt_to_fix_pg_socket_issue'
```
- Run bundle install on octopi project
- Make sure that dossier is now pointing to your local branch
- Run reports to make sure it is still working.