### PR TITLE
Fix use of with_indifferent_access so it works on and after rails 5.1

### DIFF
--- a/lib/dossier/multi_report.rb
+++ b/lib/dossier/multi_report.rb
@@ -12,11 +12,12 @@ class Dossier::MultiReport
   end
 
   def initialize(options = {})
+    self.options = self.options.to_unsafe_h if self.options.respond_to?(:to_unsafe_h)
     self.options = options.dup.with_indifferent_access
   end
 
   def reports
-    @reports ||= self.class.reports.map { |report| 
+    @reports ||= self.class.reports.map { |report|
       report.new(options).tap { |r|
         r.parent = self
       }
@@ -30,7 +31,7 @@ class Dossier::MultiReport
   def formatter
     Module.new
   end
-  
+
   def dom_id
     nil
   end

--- a/lib/dossier/report.rb
+++ b/lib/dossier/report.rb
@@ -23,8 +23,9 @@ module Dossier
     def self.filename
       "#{report_name.parameterize}-report_#{Time.now.strftime('%Y-%m-%d_%H-%M-%S-%Z')}"
     end
-    
+
     def initialize(options = {})
+      options = options.to_unsafe_h if options.respond_to?(:to_unsafe_h)
       @options = options.dup.with_indifferent_access
     end
 
@@ -70,7 +71,7 @@ module Dossier
     def renderer
       @renderer ||= Renderer.new(self)
     end
-    
+
     delegate :render, to: :renderer
 
     private


### PR DESCRIPTION
Want to see if this fixes an issue where, particularly, we can't download the Tally Verification report on mobile (Barbados).

Also, if you're on mobile with a big enough viewport and can see the "Download CSV" and "Download XLS" buttons those also don't act as expected.