### PR TITLE
Adds support for using DOSSIER_DATABASE_URL

### DIFF
--- a/lib/dossier/configuration.rb
+++ b/lib/dossier/configuration.rb
@@ -24,7 +24,7 @@ module Dossier
     end
    
     def dburl_config
-      Dossier::ConnectionUrl.new.to_hash if ENV.has_key? DB_KEY
+      Dossier::ConnectionUrl.new(ENV['DOSSIER_DATABASE_URL']).to_hash if ENV.has_key? DB_KEY
     end
 
     private


### PR DESCRIPTION
Allow using DOSSIER_DATABASE_URL to have dossier point to a different database.

    Dossier uses DATABASE_URL by default but Dossier::ConnectionUrl initializer
    allows you to pass a database URL:
        def initialize(url = nil)
          @uri = URI.parse(url || ENV.fetch('DATABASE_URL'))
        end

    However, when Dossier::Configuration gets the DB URL config, it does
    not pass in a URL to Dossier:ConnectionUrl:
        def dburl_config
          Dossier::ConnectionUrl.new.to_hash if ENV.has_key? DB_KEY
        end

    Notice the call to new has no url argument.

    By changing to the following:

        def dburl_config
          Dossier::ConnectionUrl.new(ENV['DOSSIER_DATABASE_URL']).to_hash if ENV.has_key? DB_KEY
        end

    We now allow ConnectionUrl to be initialized with DOSSIER_DATABASE_URL if one is present.
    If none, is present, ENV['DOSSIER_DATABASE_URL'] will return nil, and dossier will
    just use current behavior and fetch the DATABASE_URL

    This commit will allow users of Dossier on Heroku to add a new config for DOSSIER_DATABASE_URL
    to point dossier to a different database than the main application (e.g. a follower database).