### PR TITLE
Lazy load config.cache_store setting

### DIFF
--- a/lib/dossier/renderer.rb
+++ b/lib/dossier/renderer.rb
@@ -45,7 +45,9 @@ module Dossier
       include ViewContextWithReportFormatter
 
       attr_reader :report
-      config.cache_store = ActionController::Base.cache_store
+      ActiveSupport.on_load(:action_controller) do
+        config.cache_store = ActionController::Base.cache_store
+      end
 
       layout 'dossier/layouts/application'
 
@@ -58,7 +60,7 @@ module Dossier
         Module.new do
           include Rails.application.helpers
           include Rails.application.routes.url_helpers
-          
+
           def default_url_options
             {}
           end


### PR DESCRIPTION
While upgrading the octopi codebase to rails 6, we get autoloading warnings from `dossier`. This is because of the reference to `ActionController::Base`. Wrapping this reference in an `on_load` hook, allows us to proceed with as few changes as possible.